### PR TITLE
fixed the small black rectangle at the top left corner

### DIFF
--- a/src/components/CanvasAnimation.jsx
+++ b/src/components/CanvasAnimation.jsx
@@ -201,6 +201,9 @@ const CanvasAnimation = () => {
         left: 0,
         zIndex: 1,
         background: "#000",
+        width: "100vw",
+        height: "100vh",
+        display: "block",
       }}
     />
   );


### PR DESCRIPTION
##  Fix Canvas Animation

**Problem**: Small black rectangle appearing at top-left corner while loading the landing page

**Solution**: Added viewport dimensions to canvas :
- `width: "100vw"` - full viewport width
- `height: "100vh"` - full viewport height  
- `display: "block"` - prevent inline rendering artifacts

**Files Changed**: `src/components/CanvasAnimation.jsx`

**Result**: Canvas now properly covers entire viewport.